### PR TITLE
🩹 Don't save disposed widgets

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/quotes': [
       'error',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "https://github.com/s-weigand/jupyterlab_autosave_on_focus_change.git"
   },
   "scripts": {
-    "build": "jlpm run build:lib && jlpm run build:labextension:dev",
+    "build": "jlpm run build:lib && jlpm run build:labextension",
+    "build:dev": "jlpm run build:lib && jlpm run build:labextension:dev",
     "build:prod": "jlpm run clean && jlpm run build:lib && jlpm run build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -171,9 +171,18 @@ export class FocusChangeAutoSaveTracker {
    */
   saveDocumentWidget(widget: Widget): void {
     const context = this._docManager.contextForWidget(widget);
-    if (this._excludeMatcher.match(context.path) === false) {
-      context.save();
-      this._debug_printer('Saving: ', context.path);
+    if (
+      this._excludeMatcher.match(context.path) === false &&
+      context.isDisposed === false
+    ) {
+      context
+        .save()
+        .then(() => {
+          this._debug_printer('Saving: ', context.path);
+        })
+        .catch(reason => {
+          this._debug_printer(`Error saving: ${context.path}`, reason);
+        });
     }
   }
 

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -151,23 +151,17 @@ export class FocusChangeAutoSaveTracker {
    * @returns Document Widget or undefined
    */
   getWidgetFromEvent(event: FocusEvent): Widget | undefined {
-    if (this._saveOnCellFocusChange !== true) {
+    const currentTarget = event.currentTarget as HTMLElement;
+    if (this._saveOnCellFocusChange === false) {
       const relatedTarget = event.relatedTarget as HTMLElement;
-      const target = event.target as HTMLElement;
       if (
-        relatedTarget === null ||
-        relatedTarget.contains(target) || // cell is in focused widget
-        relatedTarget.nodeName !== 'DIV' // newly created cell (TEXTAREA)
+        relatedTarget !== null &&
+        currentTarget.contains(relatedTarget) // new focused widget inside old document widget
       ) {
         return undefined;
       }
-      this._debug_printer(
-        'target in relatedTarget: ',
-        relatedTarget.contains(target),
-      );
     }
-    const targetNode = event.currentTarget as HTMLElement;
-    return this._nodes.get(targetNode);
+    return this._nodes.get(currentTarget);
   }
 
   /**


### PR DESCRIPTION
When closing a document widget sometimes the following error was raised.
![grafik](https://user-images.githubusercontent.com/9513634/117425619-3aca8880-af23-11eb-8722-c80cdb140f4e.png)

Changes:
- Made widget filtering when not saving cells more robust (now it checks if the newly focused widget was in the old document widget)
- Check if widget is disposed before saving and catch save promise
- Added eslint rule to check for dangling promisses
- Changed building the extension to not use dev mode (no more debug console messages in published extension)