### PR TITLE
✨Update jupyter_packaging and add test_isolated job to build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,49 @@ jobs:
 
           check-manifest -v
 
+          pip install build
+          python -m build --sdist
+          cp dist/*.tar.gz jupyterlab_autosave_on_focus_change.tar.gz
+          pip uninstall -y jupyterlab_autosave_on_focus_change jupyterlab
+          rm -rf jupyterlab_autosave_on_focus_change
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jupyterlab_autosave_on_focus_change-sdist
+          path: jupyterlab_autosave_on_focus_change.tar.gz
+
+  test_isolated:
+    name: Test isolated
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+        architecture: 'x64'
+    - uses: actions/download-artifact@v2
+      with:
+        name: jupyterlab_autosave_on_focus_change-sdist
+    - name: Install and Test
+      run: |
+        set -eux
+        # Remove NodeJS, twice to take care of system and locally installed node versions.
+        sudo rm -rf $(which node)
+        sudo rm -rf $(which node)
+        pip install jupyterlab_autosave_on_focus_change.tar.gz
+        pip install jupyterlab
+        jupyter labextension list 2>&1 | grep -ie "jupyterlab_autosave_on_focus_change.*OK"
+        python -m jupyterlab.browser_check --no-chrome-test
+
   deploy:
     name: Upload new version to PyPi
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: [build]
+    needs: [test_isolated]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,15 @@
 [build-system]
-requires = ["jupyter_packaging~=0.9,<2", "jupyterlab~=3.0"]
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.0"]
 build-backend = "jupyter_packaging.build_api"
+
+[tool.jupyter-packaging.options]
+skip-if-exists = [
+  "jupyterlab_autosave_on_focus_change/labextension/static/style.js"
+]
+ensured-targets = [
+  "jupyterlab_autosave_on_focus_change/labextension/static/style.js",
+  "jupyterlab_autosave_on_focus_change/labextension/package.json"
+]
 
 [tool.jupyter-packaging.builder]
 factory = "jupyter_packaging.npm_builder"


### PR DESCRIPTION
This change allows installing the sdist without the need to have nodejs installed.
It also adds a CI test where nodejs is installed on the runner.