### PR TITLE
🚇🩹 Fix permissions of PyPI release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     needs: [test_isolated]
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes that in #54 The PyPI release workflow was changed to use trusted workflows, but the correct permissions weren't set.